### PR TITLE
Introduce a split between XMLRPC tests and integration tests

### DIFF
--- a/jenkins-job-builder/freeipa-jobs.yaml
+++ b/jenkins-job-builder/freeipa-jobs.yaml
@@ -233,6 +233,53 @@
             report-mail-address: '{report-mail-address}'
 
 - job-template:
+    name: '{prefix}-timed-integration-{project}-{pretty_name}-domlevel-{domain_level}'
+    node: freeipa-controller-{os}{controller_suffix}
+    defaults: global
+    concurrent: false
+    description: |
+        Run FreeIPA integration tests under {suite}.
+    wrappers:
+        - workspace-cleanup
+    triggers:
+        - timed: "{timed-schedule}"
+    builders:
+        - uninstall-freeipa-packages-soft
+        - configure-updates-testing:
+            enable-updates-testing: "{enable-updates-testing}"
+        - shell: |
+            sudo dnf distro-sync --allowerasing -y
+        - install-built-rpms:
+            prefix: "{prefix}"
+            project: "{project}"
+            copr-repos: "{copr-repos}"
+        - disable-updates-testing
+        - prepare-controller
+        - shell: |
+            ENABLE_UPDATES_TESTING={enable-updates-testing} IPABRANCH={git-branch} ./prepare-hosts <<END_YAML_FILE > test-config.yaml
+            _os: {os}
+            {config_template}
+            END_YAML_FILE
+            cat test-config.yaml
+        - shell: |
+            rm -fr test_logs || :
+            mkdir test_logs
+        - shell: |
+            export IPATEST_YAML_CONFIG=$(realpath ./test-config.yaml)
+            ipa-test-config --yaml
+            ipa-run-tests --with-xunit {suite} --logging-level=DEBUG --logfile-dir=$(realpath test_logs) || :
+        - destroy-hosts
+        - uninstall-freeipa-packages
+        - cleanup-local-repo
+    publishers:
+        - nosetests-xunit
+        - archive:
+            artifacts: 'test_logs/**'
+            allow-empty: true
+        - mail-on-fail:
+            report-mail-address: '{report-mail-address}'
+
+- job-template:
     name: '{prefix}-stats-{project}'
     node: master
     defaults: global

--- a/jenkins-job-builder/integration-jobs.yml
+++ b/jenkins-job-builder/integration-jobs.yml
@@ -223,7 +223,7 @@
             suite: test_integration/test_topology.py
             domain_level: 1
             controller_suffix: ''
-            config_template: |  
+            config_template: |
                 domains:
                   - hosts:
                       - name: master.ipa.test
@@ -319,3 +319,329 @@
                         role: replica
                     name: ipa.test
                     type: IPA
+
+- job-group:
+    name: timed-integration
+    jobs:
+        - '{prefix}-timed-integration-{project}-{pretty_name}-domlevel-{domain_level}':
+            pretty_name: caless
+            suite: test_integration/test_caless.py
+            controller_suffix: ''
+            config_template: |
+                domain_level: {domain_level}
+                domains:
+                  - hosts:
+                      - name: master.ipa.test
+                        role: master
+                      - name: replica.ipa.test
+                        role: replica
+                      - name: client.ipa.test
+                        role: client
+                    name: ipa.test
+                    type: IPA
+
+        - '{prefix}-timed-integration-{project}-{pretty_name}-domlevel-{domain_level}':
+            pretty_name: simple_replication
+            suite: test_integration/test_simple_replication.py
+            controller_suffix: ''
+            config_template: |
+                domain_level: {domain_level}
+                domains:
+                  - hosts:
+                      - name: master.ipa.test
+                        role: master
+                      - name: replica.ipa.test
+                        role: replica
+                    name: ipa.test
+                    type: IPA
+
+        - '{prefix}-timed-integration-{project}-{pretty_name}-domlevel-{domain_level}':
+            pretty_name: external_ca
+            suite: test_integration/test_external_ca.py
+            controller_suffix: ''
+            config_template: |
+                domain_level: {domain_level}
+                domains:
+                  - hosts:
+                      - name: master.ipa.test
+                        role: master
+                    name: ipa.test
+                    type: IPA
+
+        - '{prefix}-timed-integration-{project}-{pretty_name}-domlevel-{domain_level}':
+            pretty_name: forced_client_reenrollment
+            suite: test_integration/test_forced_client_reenrollment.py
+            controller_suffix: ''
+            config_template: |
+                domain_level: {domain_level}
+                domains:
+                  - hosts:
+                      - name: master.ipa.test
+                        role: master
+                      - name: replica.ipa.test
+                        role: replica
+                      - name: client.ipa.test
+                        role: client
+                    name: ipa.test
+                    type: IPA
+
+        - '{prefix}-timed-integration-{project}-{pretty_name}-domlevel-{domain_level}':
+            pretty_name: kerberos_flags
+            suite: test_integration/test_kerberos_flags.py
+            controller_suffix: ''
+            config_template: |
+                domain_level: {domain_level}
+                domains:
+                  - hosts:
+                      - name: master.ipa.test
+                        role: master
+                      - name: client.ipa.test
+                        role: client
+                    name: ipa.test
+                    type: IPA
+
+        - '{prefix}-timed-integration-{project}-{pretty_name}-domlevel-{domain_level}':
+            pretty_name: sudo
+            suite: test_integration/test_sudo.py
+            controller_suffix: ''
+            config_template: |
+                domain_level: {domain_level}
+                domains:
+                  - hosts:
+                      - name: master.ipa.test
+                        role: master
+                      - name: client.ipa.test
+                        role: client
+                    name: ipa.test
+                    type: IPA
+
+        - '{prefix}-timed-integration-{project}-{pretty_name}-domlevel-{domain_level}':
+            pretty_name: advise
+            suite: test_integration/test_advise.py
+            controller_suffix: ''
+            config_template: |
+                domain_level: {domain_level}
+                domains:
+                  - hosts:
+                      - name: master.ipa.test
+                        role: master
+                    name: ipa.test
+                    type: IPA
+
+        - '{prefix}-timed-integration-{project}-{pretty_name}-domlevel-{domain_level}':
+            pretty_name: basic_trust
+            suite: test_integration/test_trust.py
+            controller_suffix: '-trusts'
+            config_template: |
+                domain_level: {domain_level}
+                domains:
+                  - hosts:
+                      - name: master.ipa.test
+                        role: trust_master
+                    name: ipa.test
+                    type: TRUST_IPA
+                  - hosts:
+                      - name: ad.ad.test
+                        role: ad
+                      - name: child.child.ad.test
+                        role: ad_subdomain
+                    name: ad.test
+                    type: AD
+
+        - '{prefix}-timed-integration-{project}-{pretty_name}-domlevel-{domain_level}':
+            pretty_name: legacy_clients
+            suite: test_integration/test_legacy_clients.py
+            controller_suffix: '-trusts'
+            config_template: |
+                domain_level: {domain_level}
+                domains:
+                  - hosts:
+                      - name: master.ipa.test
+                        role: trust_master
+                      - name: legacy_client_sssd_redhat.ipa.test
+                        role: legacy_client_sssd_redhat
+                      - name: legacy_client_nss_ldap_redhat.ipa.test
+                        role: legacy_client_nss_ldap_redhat
+                      - name: legacy_client_nss_pam_ldapd_redhat.ipa.test
+                        role: legacy_client_nss_pam_ldapd_redhat
+                    name: ipa.test
+                    type: TRUST_IPA
+                  - hosts:
+                      - name: ad.ad.test
+                        role: ad
+                      - name: child.child.ad.test
+                        role: ad_subdomain
+                    name: ad.test
+                    type: AD
+
+        - '{prefix}-timed-integration-{project}-{pretty_name}-domlevel-{domain_level}':
+            pretty_name: dnssec
+            suite: test_integration/test_dnssec.py
+            controller_suffix: ''
+            config_template: |
+                domain_level: {domain_level}
+                domains:
+                  - hosts:
+                      - name: master.ipa.test
+                        role: master
+                      - name: replica.ipa.test
+                        role: replica
+                      - name: replica.ipa.test
+                        role: replica
+                    name: ipa.test
+                    type: IPA
+
+        - '{prefix}-timed-integration-{project}-{pretty_name}-domlevel-{domain_level}':
+            pretty_name: backup_and_restore
+            suite: test_integration/test_backup_and_restore.py
+            controller_suffix: ''
+            config_template: |
+                domain_level: {domain_level}
+                domains:
+                  - hosts:
+                      - name: master.ipa.test
+                        role: master
+                    name: ipa.test
+                    type: IPA
+
+        - '{prefix}-timed-integration-{project}-{pretty_name}-domlevel-{domain_level}':
+            pretty_name: service_permissions
+            suite: test_integration/test_service_permissions.py
+            controller_suffix: ''
+            config_template: |
+                domain_level: {domain_level}
+                domains:
+                  - hosts:
+                      - name: master.ipa.test
+                        role: master
+                    name: ipa.test
+                    type: IPA
+
+        - '{prefix}-timed-integration-{project}-{pretty_name}-domlevel-{domain_level}':
+            pretty_name: topology
+            suite: test_integration/test_topology.py
+            domain_level: 1
+            controller_suffix: ''
+            config_template: |
+                domains:
+                  - hosts:
+                      - name: master.ipa.test
+                        role: master
+                      - name: replica.ipa.test
+                        role: replica
+                      - name: replica.ipa.test
+                        role: replica
+                    name: ipa.test
+                    type: IPA
+
+        - '{prefix}-timed-integration-{project}-{pretty_name}-domlevel-{domain_level}':
+            pretty_name: vault
+            suite: test_integration/test_vault.py
+            controller_suffix: ''
+            config_template: |
+                domain_level: {domain_level}
+                domains:
+                  - hosts:
+                      - name: master.ipa.test
+                        role: master
+                      - name: replica.ipa.test
+                        role: replica
+                    name: ipa.test
+                    type: IPA
+
+        - '{prefix}-timed-integration-{project}-{pretty_name}-domlevel-{domain_level}':
+            pretty_name: customized_ds_config_install
+            suite: test_integration/test_customized_ds_config_install.py
+            controller_suffix: ''
+            config_template: |
+                domain_level: {domain_level}
+                domains:
+                  - hosts:
+                      - name: master.ipa.test
+                        role: master
+                      - name: replica.ipa.test
+                        role: replica
+                    name: ipa.test
+                    type: IPA
+
+        - '{prefix}-timed-integration-{project}-{pretty_name}-domlevel-{domain_level}':
+            pretty_name: installation
+            suite: test_integration/test_installation.py
+            controller_suffix: ''
+            config_template: |
+                domain_level: {domain_level}
+                domains:
+                  - hosts:
+                      - name: master.ipa.test
+                        role: master
+                      - name: replica.ipa.test
+                        role: replica
+                      - name: replica.ipa.test
+                        role: replica
+                      - name: replica.ipa.test
+                        role: replica
+                    name: ipa.test
+                    type: IPA
+
+        - '{prefix}-timed-integration-{project}-{pretty_name}-domlevel-{domain_level}':
+            pretty_name: replication_layouts
+            suite: test_integration/test_replication_layouts.py
+            controller_suffix: ''
+            config_template: |
+                domain_level: {domain_level}
+                domains:
+                  - hosts:
+                      - name: master.ipa.test
+                        role: master
+                      - name: replica.ipa.test
+                        role: replica
+                      - name: replica.ipa.test
+                        role: replica
+                      - name: replica.ipa.test
+                        role: replica
+                    name: ipa.test
+                    type: IPA
+
+        - '{prefix}-timed-integration-{project}-{pretty_name}-domlevel-{domain_level}':
+            pretty_name: replica_promotion
+            suite: test_integration/test_replica_promotion.py
+            controller_suffix: ''
+            config_template: |
+                domain_level: {domain_level}
+                domains:
+                  - hosts:
+                      - name: master.ipa.test
+                        role: master
+                      - name: replica.ipa.test
+                        role: replica
+                      - name: replica.ipa.test
+                        role: replica
+                    name: ipa.test
+                    type: IPA
+
+
+- job-group:
+    name: build-and-check-fast
+    jobs:
+        - '{prefix}-stats-{project}'
+        - '{prefix}-build-{project}'
+        - '{prefix}-check-deps-{project}'
+        - '{prefix}-intree-tests-{project}'
+        - '{prefix}-outoftree-tests-{project}'
+        - '{prefix}-webui-{browser}-{project}-{prettyname}':
+            prettyname: with-dns-with-ca
+            noca: False
+            nodns: False
+            browser: firefox
+
+        - '{prefix}-webui-{browser}-{project}-{prettyname}':
+            prettyname: no-dns-no-ca
+            noca: True
+            nodns: True
+            browser: firefox
+            options-dns-setup: ""
+            options-ca-setup: >
+                --http_pkcs12 star-cert.p12 \
+                --dirsrv_pkcs12 star-cert.p12 \
+                --http_pin $FREEIPACI_STAR_CERT_PIN --dirsrv_pin $FREEIPACI_STAR_CERT_PIN \
+                --root-ca-file star-cert-ca.crt

--- a/projects/project.yaml.example
+++ b/projects/project.yaml.example
@@ -8,17 +8,18 @@
     git-browser-url: https://git.fedorahosted.org/cgit/freeipa.git/
     options-dns-setup: >
         --setup-dns
-        --forwarder=$FREEIPACI_DNS_FORWARDER
+        --auto-forwarders
+        --auto-reverse
     options-ca-setup: ""
     domain_level:
         - 0
         - 1
     report-mail-address: your.email@example
     copr-repos:
-        - mkosek/freeipa-master
+        - @freeipa/freeipa-master
     enable-updates-testing: true
+    # timed-schedule is used with timed-integration
+    # - timed-schedule: 0 23 * * *
     jobs:
         - build-and-check
         - docs
-
-# vi: set ft=yaml :


### PR DESCRIPTION
The split consists of new job templates and job groups that
divide the test execution as follows:
- build and XMLRPC tests are bound to SCM polling in short intervals
- integration tests now can be scheduled independently via cron,
  taking build artifacts from its respective build job

This change allows to optimize the resource usage by running the heavy
load tests only in specified times and not after each SCM change.
