### PR TITLE
Improved testrun logging for integration tests

### DIFF
--- a/jenkins-job-builder/freeipa-jobs.yaml
+++ b/jenkins-job-builder/freeipa-jobs.yaml
@@ -328,7 +328,7 @@
         - shell: |
             export IPATEST_YAML_CONFIG=$(realpath ./test-config.yaml)
             ipa-test-config --yaml
-            ipa-run-tests --with-xunit {suite} --logging-level=DEBUG --logfile-dir=$(realpath test_logs) || :
+            ipa-run-tests -v -r a --with-xunit {suite} --logging-level=DEBUG --logfile-dir=$(realpath test_logs) || :
         - destroy-hosts
         - uninstall-freeipa-packages
         - cleanup-local-repo
@@ -378,7 +378,7 @@
         - shell: |
             export IPATEST_YAML_CONFIG=$(realpath ./test-config.yaml)
             ipa-test-config --yaml
-            ipa-run-tests --with-xunit {suite} --logging-level=DEBUG --logfile-dir=$(realpath test_logs) || :
+            ipa-run-tests -v -r a --with-xunit {suite} --logging-level=DEBUG --logfile-dir=$(realpath test_logs) || :
         - destroy-hosts
         - uninstall-freeipa-packages
         - cleanup-local-repo


### PR DESCRIPTION
'-v' flag shows us the names of test classes and test functions so that we
know which exactly test has failed.
'- r a' tells the framework to report the reasons for xfails and skips which is
also a useful thing to see in the test output
