### PR TITLE
Partitioned replica_promotion tests

### DIFF
--- a/jenkins-job-builder/freeipa-jobs.yaml
+++ b/jenkins-job-builder/freeipa-jobs.yaml
@@ -328,7 +328,7 @@
         - shell: |
             export IPATEST_YAML_CONFIG=$(realpath ./test-config.yaml)
             ipa-test-config --yaml
-            ipa-run-tests -v -r a --with-xunit {suite} --logging-level=DEBUG --logfile-dir=$(realpath test_logs) || :
+            ipa-run-tests -v -r a --with-xunit -k {filter} {suite} --logging-level=DEBUG --logfile-dir=$(realpath test_logs) || :
         - destroy-hosts
         - uninstall-freeipa-packages
         - cleanup-local-repo
@@ -378,7 +378,7 @@
         - shell: |
             export IPATEST_YAML_CONFIG=$(realpath ./test-config.yaml)
             ipa-test-config --yaml
-            ipa-run-tests -v -r a --with-xunit {suite} --logging-level=DEBUG --logfile-dir=$(realpath test_logs) || :
+            ipa-run-tests -v -r a --with-xunit -k {filter} {suite} --logging-level=DEBUG --logfile-dir=$(realpath test_logs) || :
         - destroy-hosts
         - uninstall-freeipa-packages
         - cleanup-local-repo

--- a/jenkins-job-builder/integration-jobs.yml
+++ b/jenkins-job-builder/integration-jobs.yml
@@ -28,6 +28,7 @@
             pretty_name: caless
             suite: test_integration/test_caless.py
             controller_suffix: ''
+            filter: '""'
             config_template: |
                 domain_level: {domain_level}
                 domains:
@@ -45,6 +46,7 @@
             pretty_name: simple_replication
             suite: test_integration/test_simple_replication.py
             controller_suffix: ''
+            filter: '""'
             config_template: |
                 domain_level: {domain_level}
                 domains:
@@ -60,6 +62,7 @@
             pretty_name: external_ca
             suite: test_integration/test_external_ca.py
             controller_suffix: ''
+            filter: '""'
             config_template: |
                 domain_level: {domain_level}
                 domains:
@@ -73,6 +76,7 @@
             pretty_name: forced_client_reenrollment
             suite: test_integration/test_forced_client_reenrollment.py
             controller_suffix: ''
+            filter: '""'
             config_template: |
                 domain_level: {domain_level}
                 domains:
@@ -90,6 +94,7 @@
             pretty_name: kerberos_flags
             suite: test_integration/test_kerberos_flags.py
             controller_suffix: ''
+            filter: '""'
             config_template: |
                 domain_level: {domain_level}
                 domains:
@@ -105,6 +110,7 @@
             pretty_name: sudo
             suite: test_integration/test_sudo.py
             controller_suffix: ''
+            filter: '""'
             config_template: |
                 domain_level: {domain_level}
                 domains:
@@ -120,6 +126,7 @@
             pretty_name: advise
             suite: test_integration/test_advise.py
             controller_suffix: ''
+            filter: '""'
             config_template: |
                 domain_level: {domain_level}
                 domains:
@@ -133,6 +140,7 @@
             pretty_name: basic_trust
             suite: test_integration/test_trust.py
             controller_suffix: '-trusts'
+            filter: '""'
             config_template: |
                 domain_level: {domain_level}
                 domains:
@@ -153,6 +161,7 @@
             pretty_name: legacy_clients
             suite: test_integration/test_legacy_clients.py
             controller_suffix: '-trusts'
+            filter: '""'
             config_template: |
                 domain_level: {domain_level}
                 domains:
@@ -179,6 +188,7 @@
             pretty_name: dnssec
             suite: test_integration/test_dnssec.py
             controller_suffix: ''
+            filter: '""'
             config_template: |
                 domain_level: {domain_level}
                 domains:
@@ -196,6 +206,7 @@
             pretty_name: backup_and_restore
             suite: test_integration/test_backup_and_restore.py
             controller_suffix: ''
+            filter: '""'
             config_template: |
                 domain_level: {domain_level}
                 domains:
@@ -209,6 +220,7 @@
             pretty_name: service_permissions
             suite: test_integration/test_service_permissions.py
             controller_suffix: ''
+            filter: '""'
             config_template: |
                 domain_level: {domain_level}
                 domains:
@@ -223,6 +235,7 @@
             suite: test_integration/test_topology.py
             domain_level: 1
             controller_suffix: ''
+            filter: '""'
             config_template: |
                 domains:
                   - hosts:
@@ -239,6 +252,7 @@
             pretty_name: vault
             suite: test_integration/test_vault.py
             controller_suffix: ''
+            filter: '""'
             config_template: |
                 domain_level: {domain_level}
                 domains:
@@ -254,6 +268,7 @@
             pretty_name: customized_ds_config_install
             suite: test_integration/test_customized_ds_config_install.py
             controller_suffix: ''
+            filter: '""'
             config_template: |
                 domain_level: {domain_level}
                 domains:
@@ -269,6 +284,7 @@
             pretty_name: installation
             suite: test_integration/test_installation.py
             controller_suffix: ''
+            filter: '""'
             config_template: |
                 domain_level: {domain_level}
                 domains:
@@ -288,6 +304,7 @@
             pretty_name: replication_layouts
             suite: test_integration/test_replication_layouts.py
             controller_suffix: ''
+            filter: '""'
             config_template: |
                 domain_level: {domain_level}
                 domains:
@@ -304,9 +321,60 @@
                     type: IPA
 
         - '{prefix}-integration-{project}-{pretty_name}-domlevel-{domain_level}':
-            pretty_name: replica_promotion
+            pretty_name: replica_promotion_install
             suite: test_integration/test_replica_promotion.py
             controller_suffix: ''
+            filter: '"Install"'
+            config_template: |
+                domain_level: {domain_level}
+                domains:
+                  - hosts:
+                      - name: master.ipa.test
+                        role: master
+                      - name: replica.ipa.test
+                        role: replica
+                      - name: replica.ipa.test
+                        role: replica
+                    name: ipa.test
+                    type: IPA
+
+        - '{prefix}-integration-{project}-{pretty_name}-domlevel-{domain_level}':
+            pretty_name: replica_promotion_promotion
+            suite: test_integration/test_replica_promotion.py
+            controller_suffix: ''
+            filter: '"Promotion"'
+            config_template: |
+                domain_level: {domain_level}
+                domains:
+                  - hosts:
+                      - name: master.ipa.test
+                        role: master
+                      - name: replica.ipa.test
+                        role: replica
+                    name: ipa.test
+                    type: IPA
+
+        - '{prefix}-integration-{project}-{pretty_name}-domlevel-{domain_level}':
+            pretty_name: replica_promotion_old_replica
+            suite: test_integration/test_replica_promotion.py
+            controller_suffix: ''
+            filter: '"Unprivileged or WrongClient or OldReplica"'
+            config_template: |
+                domain_level: {domain_level}
+                domains:
+                  - hosts:
+                      - name: master.ipa.test
+                        role: master
+                      - name: replica.ipa.test
+                        role: replica
+                    name: ipa.test
+                    type: IPA
+
+        - '{prefix}-integration-{project}-{pretty_name}-domlevel-{domain_level}':
+            pretty_name: replica_promotion_catch_all
+            suite: test_integration/test_replica_promotion.py
+            controller_suffix: ''
+            filter: '"not (Promotion or Install or Unprivileged or WrongClient or OldReplica)"'
             config_template: |
                 domain_level: {domain_level}
                 domains:
@@ -327,6 +395,7 @@
             pretty_name: caless
             suite: test_integration/test_caless.py
             controller_suffix: ''
+            filter: '""'
             config_template: |
                 domain_level: {domain_level}
                 domains:
@@ -344,6 +413,7 @@
             pretty_name: simple_replication
             suite: test_integration/test_simple_replication.py
             controller_suffix: ''
+            filter: '""'
             config_template: |
                 domain_level: {domain_level}
                 domains:
@@ -359,6 +429,7 @@
             pretty_name: external_ca
             suite: test_integration/test_external_ca.py
             controller_suffix: ''
+            filter: '""'
             config_template: |
                 domain_level: {domain_level}
                 domains:
@@ -372,6 +443,7 @@
             pretty_name: forced_client_reenrollment
             suite: test_integration/test_forced_client_reenrollment.py
             controller_suffix: ''
+            filter: '""'
             config_template: |
                 domain_level: {domain_level}
                 domains:
@@ -389,6 +461,7 @@
             pretty_name: kerberos_flags
             suite: test_integration/test_kerberos_flags.py
             controller_suffix: ''
+            filter: '""'
             config_template: |
                 domain_level: {domain_level}
                 domains:
@@ -404,6 +477,7 @@
             pretty_name: sudo
             suite: test_integration/test_sudo.py
             controller_suffix: ''
+            filter: '""'
             config_template: |
                 domain_level: {domain_level}
                 domains:
@@ -419,6 +493,7 @@
             pretty_name: advise
             suite: test_integration/test_advise.py
             controller_suffix: ''
+            filter: '""'
             config_template: |
                 domain_level: {domain_level}
                 domains:
@@ -432,6 +507,7 @@
             pretty_name: basic_trust
             suite: test_integration/test_trust.py
             controller_suffix: '-trusts'
+            filter: '""'
             config_template: |
                 domain_level: {domain_level}
                 domains:
@@ -452,6 +528,7 @@
             pretty_name: legacy_clients
             suite: test_integration/test_legacy_clients.py
             controller_suffix: '-trusts'
+            filter: '""'
             config_template: |
                 domain_level: {domain_level}
                 domains:
@@ -478,6 +555,7 @@
             pretty_name: dnssec
             suite: test_integration/test_dnssec.py
             controller_suffix: ''
+            filter: '""'
             config_template: |
                 domain_level: {domain_level}
                 domains:
@@ -495,6 +573,7 @@
             pretty_name: backup_and_restore
             suite: test_integration/test_backup_and_restore.py
             controller_suffix: ''
+            filter: '""'
             config_template: |
                 domain_level: {domain_level}
                 domains:
@@ -508,6 +587,7 @@
             pretty_name: service_permissions
             suite: test_integration/test_service_permissions.py
             controller_suffix: ''
+            filter: '""'
             config_template: |
                 domain_level: {domain_level}
                 domains:
@@ -522,6 +602,7 @@
             suite: test_integration/test_topology.py
             domain_level: 1
             controller_suffix: ''
+            filter: '""'
             config_template: |
                 domains:
                   - hosts:
@@ -538,6 +619,7 @@
             pretty_name: vault
             suite: test_integration/test_vault.py
             controller_suffix: ''
+            filter: '""'
             config_template: |
                 domain_level: {domain_level}
                 domains:
@@ -553,6 +635,7 @@
             pretty_name: customized_ds_config_install
             suite: test_integration/test_customized_ds_config_install.py
             controller_suffix: ''
+            filter: '""'
             config_template: |
                 domain_level: {domain_level}
                 domains:
@@ -568,6 +651,7 @@
             pretty_name: installation
             suite: test_integration/test_installation.py
             controller_suffix: ''
+            filter: '""'
             config_template: |
                 domain_level: {domain_level}
                 domains:
@@ -587,6 +671,7 @@
             pretty_name: replication_layouts
             suite: test_integration/test_replication_layouts.py
             controller_suffix: ''
+            filter: '""'
             config_template: |
                 domain_level: {domain_level}
                 domains:
@@ -602,10 +687,61 @@
                     name: ipa.test
                     type: IPA
 
-        - '{prefix}-timed-integration-{project}-{pretty_name}-domlevel-{domain_level}':
-            pretty_name: replica_promotion
+        - '{prefix}-integration-{project}-{pretty_name}-domlevel-{domain_level}':
+            pretty_name: replica_promotion_install
             suite: test_integration/test_replica_promotion.py
             controller_suffix: ''
+            filter: '"Install"'
+            config_template: |
+                domain_level: {domain_level}
+                domains:
+                  - hosts:
+                      - name: master.ipa.test
+                        role: master
+                      - name: replica.ipa.test
+                        role: replica
+                      - name: replica.ipa.test
+                        role: replica
+                    name: ipa.test
+                    type: IPA
+
+        - '{prefix}-integration-{project}-{pretty_name}-domlevel-{domain_level}':
+            pretty_name: replica_promotion_promotion
+            suite: test_integration/test_replica_promotion.py
+            controller_suffix: ''
+            filter: '"Promotion"'
+            config_template: |
+                domain_level: {domain_level}
+                domains:
+                  - hosts:
+                      - name: master.ipa.test
+                        role: master
+                      - name: replica.ipa.test
+                        role: replica
+                    name: ipa.test
+                    type: IPA
+
+        - '{prefix}-integration-{project}-{pretty_name}-domlevel-{domain_level}':
+            pretty_name: replica_promotion_old_replica
+            suite: test_integration/test_replica_promotion.py
+            controller_suffix: ''
+            filter: '"Unprivileged or WrongClient or OldReplica"'
+            config_template: |
+                domain_level: {domain_level}
+                domains:
+                  - hosts:
+                      - name: master.ipa.test
+                        role: master
+                      - name: replica.ipa.test
+                        role: replica
+                    name: ipa.test
+                    type: IPA
+
+        - '{prefix}-integration-{project}-{pretty_name}-domlevel-{domain_level}':
+            pretty_name: replica_promotion_catch_all
+            suite: test_integration/test_replica_promotion.py
+            controller_suffix: ''
+            filter: '"not (Promotion or Install or Unprivileged or WrongClient or Old)Replica"'
             config_template: |
                 domain_level: {domain_level}
                 domains:
@@ -623,6 +759,7 @@
             pretty_name: dns_locations
             suite: test_integration/test_dns_locations.py
             controller_suffix: ''
+            filter: '""'
             config_template: |
                 domain_level: {domain_level}
                 domains:


### PR DESCRIPTION
Replica promotion testsuite currently takes over 2 hours to run, which is too
slow. It was desided to split the test between several jobs to be able to run
them in parallel.
The partitioning is done by providing a filter expression to ipa-run tests
through passing a '-k <expression>'. The test classes were grouped together in
a way to reduce resource consumption as much as possible, e.g. tests that
require only one replica were separated from those requiring 2 replicas
