### PR TITLE
out-of-tree-tests: cleaning env adjustments

### DIFF
--- a/jenkins-job-builder/builders/ipa-installers.yml
+++ b/jenkins-job-builder/builders/ipa-installers.yml
@@ -50,6 +50,8 @@
         - shell: |
             # kra installation
             sudo ipa-kra-install -U --password="${FREEIPACI_PASSWORD}"
+            # clean in-memory cache
+            ipa vaultconfig_show || :
 
 - builder:
     name: trust-setup

--- a/jenkins-job-builder/builders/test-env-setup.yml
+++ b/jenkins-job-builder/builders/test-env-setup.yml
@@ -58,6 +58,8 @@
             sudo pkidestroy -s CA -i pki-tomcat || :
             sudo systemctl reset-failed pki-tomcatd@pki-tomcat.service || :
             sudo systemctl restart NetworkManager.service || :
+            sudo rm -rf /var/lib/sss/db/* || :
+            sudo systemctl restart gssproxy.service || :
 
 ### RPM installation
 


### PR DESCRIPTION
delete sssd db, restart gssproxy and clean in-memory cache by
running ipa "vaultconfig_show" in order to simulate clean env

https://pagure.io/freeipa/issue/6787

Signed-off-by: Michal Reznik <mreznik@redhat.com>