### PR TITLE
project.yaml.example: change scalar indicator

### DIFF
--- a/projects/project.yaml.example
+++ b/projects/project.yaml.example
@@ -6,7 +6,7 @@
     git-branch: master
     git-url: git://git.fedorahosted.org/git/freeipa.git
     git-browser-url: https://git.fedorahosted.org/cgit/freeipa.git/
-    options-dns-setup: >
+    options-dns-setup: >-
         --setup-dns
         --auto-forwarders
         --auto-reverse


### PR DESCRIPTION
Change ">" scalar indicator to ">-"  as in the options-dns-setup
it will otherwise put a new line at the end and the entire command
will fail.