### PR TITLE
job-templates: integration_tests - soft uninstall

### DIFF
--- a/jenkins-job-builder/job-templates/integration-tests.yml
+++ b/jenkins-job-builder/job-templates/integration-tests.yml
@@ -97,7 +97,7 @@
             test_filter: "{test_filter}"
         - compress-collected-logs
         - destroy-hosts
-        - uninstall-freeipa-packages
+        - uninstall-freeipa-packages-soft
         - cleanup-local-repo
     publishers:
         - nosetests-xunit
@@ -107,4 +107,3 @@
         - mail-on-fail:
             report-mail-address: '{report-mail-address}'
         - workspace-cleanup
-


### PR DESCRIPTION
use "uninstall-freeipa-packages-soft" so a test is not marked as
failed when e.g. some scriptlet fails. This is implemented mainly
for container controllers as they do not have systemd.